### PR TITLE
CoinGecko integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"@vyper-protocol/rust-decimal-wrapper": "^0.1.3",
 		"bignumber.js": "^9.1.0",
 		"classnames": "^2.3.2",
+		"coingecko-api": "^1.0.10",
 		"evergreen-ui": "^6.10.3",
 		"moment": "^2.29.4",
 		"next": "^12.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2582,6 +2582,11 @@ clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==
 
+coingecko-api@^1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/coingecko-api/-/coingecko-api-1.0.10.tgz#ac8694d5999f00727fe55f0078ce2917603076b2"
+  integrity sha512-7YLLC85+daxAw5QlBWoHVBVpJRwoPr4HtwanCr8V/WRjoyHTa1Lb9DQAvv4MDJZHiz4no6HGnDQnddtjV35oRA==
+
 color-convert@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"


### PR DESCRIPTION
Instead of creating a custom integration, we'll use [this](https://github.com/miscavage/CoinGecko-API) library when needed.

Close #32 