### PR TITLE
42 - fix Link to cover nav item edges

### DIFF
--- a/src/components/organisms/TopBar/TopBar.module.scss
+++ b/src/components/organisms/TopBar/TopBar.module.scss
@@ -25,6 +25,8 @@
 				font-size: 15px;
 				color: var(--color-text-disabled);
 				font-weight: 500;
+				height: 100%;
+				display: block;
 			}
 
 			svg {


### PR DESCRIPTION
- Fixed Link element to cover the entire height of the enclosing div.

Closes #42 