### PR TITLE
118 - Fix PNL after settlement

### DIFF
--- a/src/api/otc-state/fetchOtcState.ts
+++ b/src/api/otc-state/fetchOtcState.ts
@@ -30,6 +30,12 @@ export const fetchOtcState = async (provider: AnchorProvider, otcStateAddress: P
 	res.depositExpirationAt = accountInfo.depositEnd.toNumber() * 1000;
 	res.settleAvailableFromAt = accountInfo.settleStart.toNumber() * 1000;
 	res.settleExecuted = accountInfo.settleExecuted;
+
+	if (res.settleExecuted) {
+		// @ts-ignore
+		res.priceAtSettlement = new RustDecimalWrapper(new Uint8Array(trancheConfigAccountInfo.trancheData.reserveFairValue.value[0])).toNumber();
+	}
+
 	res.buyerDepositAmount = accountInfo.seniorDepositAmount.toNumber() / 10 ** res.reserveMintInfo.decimals;
 	res.sellerDepositAmount = accountInfo.juniorDepositAmount.toNumber() / 10 ** res.reserveMintInfo.decimals;
 

--- a/src/pages/contract/summary/[id].tsx
+++ b/src/pages/contract/summary/[id].tsx
@@ -113,7 +113,7 @@ const SummaryPageId = () => {
 							<div className={styles.content}>
 								{rateStateQuery?.data?.settleExecuted ? (
 									<div className={styles.column}>
-										<p>Price at settlement</p>
+										<p>Settlement price</p>
 										<p>{formatWithDecimalDigits(rateStateQuery?.data?.priceAtSettlement)}</p>
 									</div>
 								) : (

--- a/src/pages/contract/summary/[id].tsx
+++ b/src/pages/contract/summary/[id].tsx
@@ -111,10 +111,18 @@ const SummaryPageId = () => {
 							{/* DETAILS */}
 
 							<div className={styles.content}>
-								<div className={styles.column}>
-									<p>Current Price</p>
-									<p>{formatWithDecimalDigits(rateStateQuery?.data?.rateState.aggregatorLastValue)}</p>
-								</div>
+								{rateStateQuery?.data?.settleExecuted ? (
+									<div className={styles.column}>
+										<p>Price at settlement</p>
+										<p>{formatWithDecimalDigits(rateStateQuery?.data?.priceAtSettlement)}</p>
+									</div>
+								) : (
+									<div className={styles.column}>
+										<p>Current Price</p>
+										<p>{formatWithDecimalDigits(rateStateQuery?.data?.rateState.aggregatorLastValue)}</p>
+									</div>
+								)}
+
 								<div className={styles.column}>
 									<p>Strike</p>
 									<p>{formatWithDecimalDigits(rateStateQuery?.data?.redeemLogicState.strike)}</p>


### PR DESCRIPTION
Reading settlement price from vyper core reserve fair value and saving in the `OtcState`. Conditionally using that price or the last aggregator value during pnl calculation if the settlement has been executed.

Close #118 