### PR TITLE
264- adjust settle button render logic

### DIFF
--- a/src/components/organisms/actionButtons/SettleButton.tsx
+++ b/src/components/organisms/actionButtons/SettleButton.tsx
@@ -32,12 +32,7 @@ const SettleButton = ({ otcStatePubkey }: { otcStatePubkey: string }) => {
 		}
 	};
 
-	if (
-		rateStateQuery?.data === undefined &&
-		!rateStateQuery?.data?.isSettlementAvailable() &&
-		!rateStateQuery?.data?.buyerWallet !== undefined &&
-		!rateStateQuery?.data?.sellerWallet !== undefined
-	) {
+	if (rateStateQuery?.data === undefined && !rateStateQuery?.data?.isSettlementAvailable()) {
 		return <></>;
 	}
 

--- a/src/components/organisms/actionButtons/SettleButton.tsx
+++ b/src/components/organisms/actionButtons/SettleButton.tsx
@@ -16,6 +16,7 @@ const SettleButton = ({ otcStatePubkey }: { otcStatePubkey: string }) => {
 
 	const provider = new AnchorProvider(connection, wallet, {});
 	const rateStateQuery = useGetFetchOTCStateQuery(connection, otcStatePubkey);
+	console.log(rateStateQuery);
 	const [isLoading, setIsLoading] = useState(false);
 
 	const onSettleClick = async () => {
@@ -31,7 +32,12 @@ const SettleButton = ({ otcStatePubkey }: { otcStatePubkey: string }) => {
 		}
 	};
 
-	if (rateStateQuery?.data === undefined || !rateStateQuery?.data?.isSettlementAvailable()) {
+	if (
+		rateStateQuery?.data === undefined &&
+		!rateStateQuery?.data?.isSettlementAvailable() &&
+		!rateStateQuery?.data?.buyerWallet !== undefined &&
+		!rateStateQuery?.data?.sellerWallet !== undefined
+	) {
 		return <></>;
 	}
 

--- a/src/models/ChainOtcState.ts
+++ b/src/models/ChainOtcState.ts
@@ -90,7 +90,7 @@ export class ChainOtcState extends AbsOtcState {
 	}
 
 	isSettlementAvailable(): boolean {
-		return Date.now() > this.settleAvailableFromAt && !this.settleExecuted;
+		return Date.now() > this.settleAvailableFromAt && !this.settleExecuted && this.buyerWallet !== undefined && this.sellerWallet !== undefined;
 	}
 
 	isClaimSeniorAvailable(currentUserWallet: PublicKey | undefined): boolean {


### PR DESCRIPTION
Add condition to render Settle Button only when the buyer wallet and seller wallet exists. Please correct me if my understanding is wrong.

```
if the contract has not be funded by both parties, but just from one of the two, then there is no possible settlement for the transaction and therefore the button is not needed to show up
```

My thought process is that in order for a contract to be funded by both parties, that means that the buyer and seller must fund it first, thus the data of the buyer and seller wallet should be present when it's funded.

Closes #264 